### PR TITLE
feat(icons): use platform icons if they exist

### DIFF
--- a/hooks/generateIcons.js
+++ b/hooks/generateIcons.js
@@ -1,23 +1,21 @@
 #!/usr/bin/env node
 const path = require('path');
 const os = require('os');
+const fs = require('fs');
 const isImagemagickInstalled = require('app-icon/src/imagemagick/is-imagemagick-installed');
 const labelImage = require('app-icon/src/label/label-image');
 const generate = require('app-icon/src/generate');
+
+const LABEL_TOP = process.env['ICON_LABEL_TOP'] || '';
+const LABEL_BOTTOM = process.env['ICON_LABEL_BOTTOM'] || '';
+const DEFAULT_ICON_PATH = process.env['ICON_INPUT'] || 'resources/icon.png';
 
 module.exports = function(ctx) {
   return run(ctx);
 };
 
 function run(cordovaContext) {
-  const input = process.env['ICON_INPUT'] || 'resources/icon.png';
-  const output = path.join(os.tmpdir(), 'icon-label.png');
-
-  const label_top = process.env['ICON_LABEL_TOP'] || '';
-  const label_bottom = process.env['ICON_LABEL_BOTTOM'] || '';
-
-  const platforms = cordovaContext.opts.platforms.join(',');
-  const search = '';
+  const platforms = cordovaContext.opts.platforms;
 
   return isImagemagickInstalled()
     .catch(err => {
@@ -30,15 +28,58 @@ function run(cordovaContext) {
         return process.exit(1);
       }
 
-      //  Label the icon
-      return new Promise((resolve, reject) => {
-        if (!label_top && !label_bottom) return resolve(input);
-        labelImage(input, output, label_top, label_bottom).then(() => {
-          return resolve(output);
-        });
-      });
-    })
-    .then(icon => {
-      return generate({ sourceIcon: icon, search, platforms });
+      return checkPlatformIcons(platforms)
+        .then(generateLabels)
+        .then(generateIcons)
     });
+}
+
+function checkPlatformIcons(platforms) {
+  return Promise.all(platforms.map(checkPlatformIcon));
+}
+
+function checkPlatformIcon(platform) {
+  const platformFolderName = platform.toLowerCase();
+  const platformIconPath = `resources/${platformFolderName}/icon.png`;
+
+  return new Promise((resolve) => {
+    fs.exists(platformIconPath, (exists) => {
+      const finalIconPath = (exists) ?
+        `resources/${platformFolderName}/icon.png` :
+        DEFAULT_ICON_PATH;
+      resolve({ platform: platformFolderName, iconPath: finalIconPath });
+    });
+  });
+}
+
+function generateLabels(icons) {
+  const output = path.join(os.tmpdir(), 'icon-label');
+
+  return Promise.all(
+    icons.map(
+      ({ platform, iconPath }) => {
+        const outputIcon = `${output}-${platform}.png`;
+
+        return new Promise((resolve, reject) => {
+          if (!LABEL_TOP && !LABEL_BOTTOM) return resolve({ platform, iconPath });
+          labelImage(iconPath, outputIcon, LABEL_TOP, LABEL_BOTTOM).then(() => {
+            return resolve({ platform, iconPath: outputIcon });
+          });
+        });
+      }
+    ),
+  ).then(iconArr => {
+    const icons = {};
+    iconArr.forEach(({ platform, iconPath }) => {
+      icons[platform] = iconPath;
+    });
+
+    return icons;
+  });
+}
+
+function generateIcons(icons) {
+  const search = '';
+
+  return Promise.all(Object.keys(icons).map(platform => generate({ sourceIcon: icons[platform], search, platforms: platform })));
 }


### PR DESCRIPTION
`ionic resources` permitía poner un ícono diferente en `/resources/{platform}/icon.png` para cada plataforma, este PR intenta volver a agregar esa funcionalidad.