### PR TITLE
Cordova compatibility

### DIFF
--- a/hooks/changeIconName.js
+++ b/hooks/changeIconName.js
@@ -11,7 +11,13 @@ module.exports = function (ctx) {
 // based on https://stackoverflow.com/a/35128023
 function run(ctx) {
   console.log('Updating AndroidManifest.xml with correct icon name');
-  const manifestPath = path.join(ctx.opts.projectRoot, 'platforms/android/AndroidManifest.xml');
+  let manifestPath = path.join(ctx.opts.projectRoot, 'platforms/android/AndroidManifest.xml');
+
+  // If it doesn't exist try cordova-android@7 path
+  if (!fs.existsSync(manifestPath)) {
+    manifestPath = path.join(ctx.opts.projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+  }
+
   const doc = xml.parseElementtreeSync(manifestPath);
   if (doc.getroot().tag !== 'manifest') {
     throw new Error(`${manifestPath} has incorrect root node name (expected "manifest")`);

--- a/hooks/generateSplashs.js
+++ b/hooks/generateSplashs.js
@@ -9,14 +9,7 @@ module.exports = function(ctx) {
 function run(cordovaContext) {
   const input = process.env['SPLASH_INPUT'] || 'resources/splash.png';
 
-  const cordova_splash = path.join(
-      'node_modules',
-      'cordova-splash',
-      'bin',
-      'cordova-splash'
-    );
-
-  return execFile(cordova_splash, [`--splash=${input}`]).then(stats => {
+  return execFile('npx', ['cordova-splash', `--splash=${input}`]).then(stats => {
     console.log(stats.stdout);
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -19,10 +24,10 @@
       "resolved": "https://registry.npmjs.org/app-icon/-/app-icon-0.6.2.tgz",
       "integrity": "sha1-OJJHPRUuHoJZTQKueQz7C+iD77w=",
       "requires": {
-        "chalk": "1.1.3",
-        "command-exists": "1.2.2",
-        "commander": "2.11.0",
-        "mkdirp": "0.5.1"
+        "chalk": "^1.1.3",
+        "command-exists": "^1.0.2",
+        "commander": "^2.9.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "balanced-match": {
@@ -30,12 +35,30 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+    },
+    "big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+    },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "requires": {
+        "big-integer": "^1.6.7"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -44,11 +67,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "colors": {
@@ -71,24 +94,76 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "cordova-common": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-2.2.5.tgz",
+      "integrity": "sha1-+TzvKtSUz8v1bEbj1hKqqctfzDI=",
+      "requires": {
+        "ansi": "^0.3.1",
+        "bplist-parser": "^0.1.0",
+        "cordova-registry-mapper": "^1.1.8",
+        "elementtree": "0.1.6",
+        "glob": "^5.0.13",
+        "minimatch": "^3.0.0",
+        "plist": "^2.1.0",
+        "q": "^1.4.1",
+        "shelljs": "^0.5.3",
+        "underscore": "^1.8.3",
+        "unorm": "^1.3.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "cordova-registry-mapper": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+      "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
+    },
     "cordova-splash": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cordova-splash/-/cordova-splash-0.10.0.tgz",
       "integrity": "sha1-BKuonXvQZV5+FLCqaGosiZZlNgY=",
       "requires": {
-        "colors": "0.6.2",
-        "fs-extra": "0.30.0",
-        "imagemagick": "0.1.3",
-        "minimist": "1.2.0",
-        "q": "1.5.1",
-        "underscore": "1.8.3",
-        "xml2js": "0.4.19"
+        "colors": "^0.6.2",
+        "fs-extra": "^0.30.0",
+        "imagemagick": "^0.1.3",
+        "minimist": "^1.2.0",
+        "q": "^1.0.1",
+        "underscore": "^1.6.0",
+        "xml2js": "^0.4.3"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "elementtree": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.6.tgz",
+      "integrity": "sha1-KsTEbqMFFsjEy9teOsdBjlkt4gw=",
+      "requires": {
+        "sax": "0.3.5"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.3.5",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-0.3.5.tgz",
+          "integrity": "sha1-iPz8H3PAyLvVt8d2ttPzUB7tBz0="
         }
       }
     },
@@ -102,11 +177,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -119,12 +194,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -137,7 +212,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "imagemagick": {
@@ -150,8 +225,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -164,7 +239,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "klaw": {
@@ -172,7 +247,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "minimatch": {
@@ -180,7 +255,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -201,13 +276,30 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "plist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "requires": {
+        "base64-js": "1.2.0",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.x"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -219,7 +311,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "sax": {
@@ -227,12 +319,17 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "shelljs": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -245,6 +342,11 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -255,14 +357,19 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "app-icon": "^0.6.2",
+    "cordova-common": "^2.2.5",
     "cordova-splash": "^0.10.0"
   },
   "author": "Christian Cook",


### PR DESCRIPTION
Agrega compatibilidad para cordova-android@7.

- Agrega `cordova-common` como dependencia en caso de que cordova no esté como dependencia en el proyecto.
- Agrega path alternativa para cordova-android@7
- Cambia el llamado a `cordova-splash` para que use npx.