### PR TITLE
 feat(adaptive-icons): added adaptive icons support for android

### DIFF
--- a/hooks/generateIcons.js
+++ b/hooks/generateIcons.js
@@ -7,7 +7,9 @@ const generate = require('app-icon/src/generate');
 
 const LABEL_TOP = process.env['ICON_LABEL_TOP'] || '';
 const LABEL_BOTTOM = process.env['ICON_LABEL_BOTTOM'] || '';
-const DEFAULT_ICON_PATH = process.env['ICON_INPUT'] || 'resources/icon.png';
+const DEFAULT_ICON_PATH = process.env['ICON_INPUT'] || 'resources/icon.png'; 
+const ADAPTIVE_ICON_BACKGROUND_PATH = process.env['ICON_BACKGROUND_INPUT'] || 'resources/android/ic_launcher_background.png';
+const ADAPTIVE_ICON_FOREGROUND_PATH = process.env['ICON_FOREGROUND_INPUT'] || 'resources/android/ic_launcher.png';
 
 module.exports = function(ctx) {
   return run(ctx);
@@ -70,6 +72,17 @@ function generateLabels(icons) {
 
 function generateIcons(icons) {
   const search = '';
-
-  return Promise.all(Object.keys(icons).map(platform => generate({ sourceIcon: icons[platform], search, platforms: platform })));
+  if (fs.existsSync(ADAPTIVE_ICON_BACKGROUND_PATH) && fs.existsSync(ADAPTIVE_ICON_FOREGROUND_PATH)) {
+    return Promise.all(Object.keys(icons).map(platform => generate({
+      sourceIcon: icons[platform],
+      backgroundIcon: ADAPTIVE_ICON_BACKGROUND_PATH,
+      foregroundIcon: ADAPTIVE_ICON_FOREGROUND_PATH,
+      search,
+      platforms: platform,
+      adaptiveIcons: true
+    })));
+  } else {
+    console.log('No adaptive icons found. Creating legacy icons.');
+    return Promise.all(Object.keys(icons).map(platform => generate({ sourceIcon: icons[platform], search, platforms: platform })));
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,34 @@
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "app-icon": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/app-icon/-/app-icon-0.6.2.tgz",
-      "integrity": "sha1-OJJHPRUuHoJZTQKueQz7C+iD77w=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/app-icon/-/app-icon-0.12.0.tgz",
+      "integrity": "sha512-gfCJ0K2o6veFwYDYLu50TvqoIakwqNgZq98/D1sv+sGyuVJyE5DzoE5D4vV/eXW0oJf6jNq3lLctfLse0pvopA==",
       "requires": {
-        "chalk": "^1.1.3",
-        "command-exists": "^1.0.2",
-        "commander": "^2.9.0",
-        "mkdirp": "^0.5.1"
+        "chalk": "^2.3.0",
+        "commander": "^2.19.0",
+        "imagemagick-cli": "^0.5.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -63,31 +72,37 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
     },
-    "command-exists": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.2.tgz",
-      "integrity": "sha1-EoGcZPr5VEbsCuB/5sr7brNwiyI="
-    },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -147,9 +162,17 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
       }
     },
     "elementtree": {
@@ -207,18 +230,23 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "imagemagick": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/imagemagick/-/imagemagick-0.1.3.tgz",
       "integrity": "sha1-dIPOoJO02fLi85aFetyIIbU3xWo="
+    },
+    "imagemagick-cli": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/imagemagick-cli/-/imagemagick-cli-0.5.0.tgz",
+      "integrity": "sha512-rlFbd3MrjysdavK0vUnwUxWvuEBHzXaK3LHVqBUIM6u+noKg5Vv2YljVmu78qEkDNIQ1+AS+17f3mgNMIe/Rlw==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -236,7 +264,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -270,6 +298,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "once": {
       "version": "1.4.0",
@@ -324,18 +357,13 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
       "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "underscore": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     }
   ],
   "dependencies": {
-    "app-icon": "^0.6.2",
+    "app-icon": "^0.12.0",
     "cordova-common": "^2.2.5",
     "cordova-splash": "1.0.0"
   },


### PR DESCRIPTION
This pull request adds support for adaptive icons for android `defaultTargetSdkVersion >= 28` (Android 8.0 Oreo).

Just place `ic_launcher_background.png` and `ic_launcher.png` in `resources/andriod/` and icons will be generated. Keep in mind that you might change the path to icon resources using the environment variables `ICON_BACKGROUND_INPUT` and `ICON_FOREGROUND_INPUT` respectively.
